### PR TITLE
Update requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ numpy
 PyQt5
 pyshp>=2.0
 pytest
-Rtree
+Rtree=0.9.3
 scipy
 shapely<1.7.0
 simple-settings


### PR DESCRIPTION
Not working with rtree 0.9.7
OSError: could not find or load spatialindex_c-64.dll
Solved when downgraded to rtree 0.9.3