### PR TITLE
Add check on IPOBO array validity and try rebuild it

### DIFF
--- a/pyteltools/slf/Serafin.py
+++ b/pyteltools/slf/Serafin.py
@@ -840,6 +840,11 @@ class SerafinHeader:
 
         self._build_ikle_2d()
 
+        # A valid IPOBO should not be equal to zero array
+        if not np.any(self.ipobo):
+          logger.warning('The IPOBO array seems corrumpted. It will be rebuild.')
+          self.build_ipobo()
+
         logger.debug('Finished reading the header')
         return self
 

--- a/pyteltools/slf/Serafin.py
+++ b/pyteltools/slf/Serafin.py
@@ -842,7 +842,7 @@ class SerafinHeader:
 
         # A valid IPOBO should not be equal to zero array
         if not np.any(self.ipobo):
-          logger.warning('The IPOBO array seems corrumpted. It will be rebuild.')
+          logger.warning('The IPOBO array seems corrupted. It will be rebuild.')
           self.build_ipobo()
 
         logger.debug('Finished reading the header')


### PR DESCRIPTION
May be it will be better to let user manually rebuild it by calling SerafinHeader.build_ipobo().
I couldn't decide

```console
Reading the input file: "maillage/input.slf" of size 595652 bytes
The IPOBO array seems corrumpted. It will be rebuild
```